### PR TITLE
Update flex.py

### DIFF
--- a/hytools/brdf/flex.py
+++ b/hytools/brdf/flex.py
@@ -148,7 +148,7 @@ def calc_flex_single(hy_obj,brdf_dict):
             coeffs= []
 
             for bin_num in hy_obj.brdf['bins']:
-                bin_mask = [kernel_samples[:,3] == bin_num]
+                bin_mask = (kernel_samples[:,3] == bin_num)
                 X = kernel_samples[:,:3][bin_mask]
                 y = band_samples[bin_mask]
                 coeffs.append(np.linalg.lstsq(X, y,rcond=-1)[0].flatten().tolist())
@@ -192,7 +192,7 @@ def calc_flex_group(actors,brdf_dict):
             band_samples = np.concatenate(band_samples)
             band_coeffs= []
             for bin_num in bins:
-                bin_mask = [kernel_samples[:,3] == bin_num]
+                bin_mask = (kernel_samples[:,3] == bin_num)
                 X = kernel_samples[:,:3][bin_mask]
                 y = band_samples[bin_mask]
                 band_coeffs.append(np.linalg.lstsq(X, y,rcond=-1)[0].flatten().tolist())


### PR DESCRIPTION
Existing FlexBRDF code works at Python 3.7 (3.7.13), but throws an error in Python 3.8 (3.8.13). It is caused by an update by Python. "Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result."

Changes are made in two functions: "calc_flex_single" and "calc_flex_group". New code uses tuples for array indexing. Tested on version 3.7.13 and 3.8.13.